### PR TITLE
fixed windows subdir-bug

### DIFF
--- a/src/ressource-utils.js
+++ b/src/ressource-utils.js
@@ -72,7 +72,7 @@ export function listFiles(directory) {
 export function convert(url) {
 	let result = url === '' ? '/' : url;
 
-	result = result.match(/([\/\.0-9a-zA-Z-_]+)(?=[\?#])?/g)[0] || result;
+	result = result.match(/([\/\.\\0-9a-zA-Z-_]+)(?=[\?#])?/g)[0] || result;
 
 	if (result.slice(-1) === '/') {
 		result += 'index';


### PR DESCRIPTION
Ohne diese Modifikation der Regular Expression wird das Framework keine Handlebars-Dateien aus "pages/"-Unterordnern auf Windows-Systemen liefern. Stattdessen wird nach einer Datei mit dem Ordernamen gesucht.

Beispiel:
"http://localhost/recipes/fisch" führt unter Windows zu einem Aufruf von convert("recipes\fisch.hbs").
Die alte Regex matcht dann "recipes" und die Funktion "convert" gibt "recipes.hbs" zurück. Diese Datei kann dann natürlich nicht gefunden werden...
