### PR TITLE
Extended Frontmatter

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -156,8 +156,13 @@ function prepareCompile(url, startDir, frontmatter) {
 		const file = fs.readFileSync(path.join(directory, filename), 'utf8');
 		const fileSplitted = file.split('---');
 
-		const fmatter = fileSplitted.length > 1 ? fileSplitted[0] : '{}';
-		const hbs = fileSplitted.length > 1 ? fileSplitted[1] : fileSplitted[0] ;
+		let fmatter = fileSplitted.length > 1 ? fileSplitted[0] : '{}';
+		let hbs = fileSplitted.length > 1 ? fileSplitted[1] : fileSplitted[0];
+
+		if (fileSplitted.length > 2 && fileSplitted[0].length == 0) {
+			fmatter = fileSplitted[1];
+			hbs = fileSplitted[2];
+		}
 
 		return parseFrontmatter(fmatter, filename, frontmatter.request).then(frontmatterLocal => {
             const page = Object.assign({}, frontmatter.page, frontmatterLocal);


### PR DESCRIPTION
Fhw-web looks for a frontmatter like this:
```handlebars
{ "front": "matter" }
---
<!DOCTYPE html>
<html>...
```
This format is different than the most common examples of a frontmatter like [this](https://jekyllrb.com/docs/front-matter/) or [this](http://assemble.io/docs/YAML-front-matter.html).
On these examples the frontmatter begins with `---` and ends again with it.
Not following this convention has the negative impact that editors (in this case VSCode) don't parse Handlebars files with a frontmatter correctly:
<img width="232" alt="Proof1" src="https://user-images.githubusercontent.com/43784252/57586300-62351900-74f4-11e9-8ee9-33cafbc1a2b9.png">

This PR changes the parsing so it allows the old way and the conventional style:
<img width="156" alt="Proof2" src="https://user-images.githubusercontent.com/43784252/57586312-7b3dca00-74f4-11e9-8bf8-7dc01bac5ba6.png">

This shouldn't break existing pages.